### PR TITLE
fix: Might have patched the 513 bug.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+key.txt
+
+main
+decode
+
+*.o
+
+# moje pliki do testowania
+małypliczek
+małypliczek.dec
+małypliczek.enc

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+all: main decode
+
+
+main: main.o
+	gcc main.o -o main
+
+decode: decode.o
+	gcc decode.o -o decode
+
+%.o: %.c
+	gcc -c $<
+
+clean:
+	rm main decode *.o
+
+distclean: clean
+	rm key.txt *.enc *.dec

--- a/decode.c
+++ b/decode.c
@@ -2,7 +2,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-#define KEY_SIZE 513
+#define KEY_SIZE 512
 #define CHUNK_SIZE 2048
 #define NOVATION 1
 

--- a/main.c
+++ b/main.c
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <time.h>
 
-#define KEY_SIZE 513
+#define KEY_SIZE 512
 #define CHUNK_SIZE 2048
 #define ARTURIA 0
 
@@ -28,8 +28,8 @@ char *base64_encode(const unsigned char *data, size_t input_length, size_t *outp
 
         encoded_data[j++] = encoding_table[(triple >> 18) & 0x3F];
         encoded_data[j++] = encoding_table[(triple >> 12) & 0x3F];
-        encoded_data[j++] = (i > input_length + 1) ? padding_char : encoding_table[(triple >> 6) & 0x3F];
-        encoded_data[j++] = (i > input_length) ? padding_char : encoding_table[triple & 0x3F];
+        encoded_data[j++] = (i >= input_length + 1) ? padding_char : encoding_table[(triple >> 6) & 0x3F];
+        encoded_data[j++] = (i >= input_length) ? padding_char : encoding_table[triple & 0x3F];
     }
 
     encoded_data[j] = '\0';


### PR DESCRIPTION
Ok, so basically everything works and is top-notch code quality, but there's one thing.

Everything sorta works when the key size is changed to 512, except the base64 encoding. If you take the encoded key through an external base64 decoder, it's 513 bytes long, because it has a 0x00 at the end.

When I popped the key from memory using a debugger, and encoded it myself, I found that the issue is lack of padding - 512 is not divisible by 3, so padding is required. The encoded string is supposed to end with `=` signs to signify mismatch from the 3-byte cells.

Long story short, chatGPT gave you a broken function.
